### PR TITLE
Fix demo.html not loading leaflet-hash-plus.js

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -4,7 +4,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/leaflet.js" integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/leaflet.css" integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="anonymous" />
 
-  <script src="https://gregrobson.uk/leaflet-hash-plus/leaflet-hash-plus.js"></script>
+  <script src="https://unpkg.com/leaflet-hash-plus@0.1.0/src/leaflet-hash-plus.js"></script>
 
   <style>
     body {


### PR DESCRIPTION
Update demo.html to use unpkg CDN for leaflet-hash-plus

Original URL is returning 502: `https://gregrobson.uk/leaflet-hash-plus/leaflet-hash-plus.js`

Suggest we resolve this by switching to unpkg CDN

*Reproduce by*
1. visit https://gregrobson.github.io/leaflet-hash-plus/demo.html
2. open network panel and notice 502 returned when retrieving leaflet-hash-plus.js